### PR TITLE
approxEqAbs comparison type changed to f64

### DIFF
--- a/src/root.zig
+++ b/src/root.zig
@@ -2619,7 +2619,7 @@ pub fn inverseDet(m: Mat, out_det: ?*F32x4) Mat {
         out_det.?.* = det;
     }
 
-    if (math.approxEqAbs(f32, det[0], 0.0, math.floatEps(f32))) {
+    if (math.approxEqAbs(f64, det[0], 0.0, math.floatEps(f64))) {
         return .{
             f32x4(0.0, 0.0, 0.0, 0.0),
             f32x4(0.0, 0.0, 0.0, 0.0),


### PR DESCRIPTION
```zig
const orthographics = math.orthographicLh(1366.0, 768.0, -1000.0, 1000.0) 
const inv = math.inverse(orthographics);
``` 
Ortographics matrix is:
```
0.0014641288, 0,            0,      0
0,            0.0026041667, 0,      0
0,            0,            0.0005, 0
0,            0,            0.5,    1
```
Determinant result is: `0.00000000190641773273548`
f32 epsilon is `math.floatEps(f32) = 0.0000001192092900`
f64 epsilon is `math.floatEps(f64) = 0.0000000000000002`

Inverse matrix result give all column 0 because of this lines: 
https://github.com/zig-gamedev/zmath/blob/634ffd67a450560c05d64fe7d86b2e45bf3aec52/src/root.zig#L2622-L2629
Increasing approxEqAbs type to f64 solve the problem.